### PR TITLE
README: make some requirements better foundable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ If you don't intend to run it on the same machine, you should set the MPD enviro
 * [`libwtk-sdl2`](../../../libwtk-sdl2) (widgets)
 * [libconfig](https://www.hyperrealm.com/libconfig/libconfig.html)
 
-## Native (host machine) Requirements
+## Build (Host only) Requirements
 
-* C++17 compiler such as Gcc
+* C++17 compiler such as `gcc`
 * `pkg-config`
 * `autoconf` & `automake` & `libtool`
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,18 @@ If you don't intend to run it on the same machine, you should set the MPD enviro
 * `SDL2_image` (cover image loading)
 * `sdl2` (rendering)
 * `libmpdclient` (communication with MPD instance)
-* `icu-uc` (lower-case conversion for case insensitive search)
+* `icu` (sometimes named `icu-uc` / `icu` / `libicu` - use lower-case conversion for case insensitive search)
 * `boost_filesystem`
 * `boost_system`
 * `boost_asio` (UDP interface for remote navigation)
-* `libwtk-sdl2` (widgets)
-* C++17
+* [`libwtk-sdl2`](../../../libwtk-sdl2) (widgets)
+* [libconfig](https://www.hyperrealm.com/libconfig/libconfig.html)
+
+## Native (host machine) Requirements
+
+* C++17 compiler such as Gcc
+* `pkg-config`
+* `autoconf` & `automake` & `libtool`
 
 # Installation
 


### PR DESCRIPTION
Add `libconfig` as it's needed and it was missing from README.
Add other usually found but not trivial deps such as pkg-config.
Add link to libwtk-sdl2 as it's not packaged by any GNU/Linux distro
as of today.

See
- https://repology.org/projects/?maintainer=&category=&inrepo=&notinrepo=&repos=&families=&repos_newest=&families_newest=&search=libwtk-sdl2
- https://repology.org/projects/?maintainer=&category=&inrepo=&notinrepo=&repos=&families=&repos_newest=&families_newest=&search=icu-uc